### PR TITLE
fix: Set LOGGING_SETUP before setup_logging() to prevent second, parallel call

### DIFF
--- a/flatterer/__init__.py
+++ b/flatterer/__init__.py
@@ -100,8 +100,8 @@ def flatten(
 ):
     global LOGGING_SETUP
     if not LOGGING_SETUP:
-        setup_logging("warning")
         LOGGING_SETUP = True
+        setup_logging("warning")
     
     using_tmp = False
     
@@ -299,8 +299,8 @@ def cli(
 
     global LOGGING_SETUP
     if not LOGGING_SETUP:
-        setup_logging("info")
         LOGGING_SETUP = True
+        setup_logging("info")
         setup_ctrlc()
     
 


### PR DESCRIPTION
Otherwise, it can panic with `Builder::init should not be called after logger initialized: SetLoggerError(())`