### PR TITLE
Updates docs: fields => fields_csv and tables => tables_csv

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -553,7 +553,7 @@ flatterer INPUT_FILE OUTPUT_DIRECTORY --fields fields.csv
 ```python
 import flatterer
 
-flatterer.flatten('inputfile.jl', 'ouput_dir', fields='fields.csv')
+flatterer.flatten('inputfile.jl', 'ouput_dir', fields_csv='fields.csv')
 ```
 
 ## Only Fields
@@ -571,7 +571,7 @@ flatterer INPUT_FILE OUTPUT_DIRECTORY --fields fields.csv --only-fields
 ```python
 import flatterer
 
-flatterer.flatten('inputfile.jl', 'ouput_dir', fields='fields.csv', only_fields=True)
+flatterer.flatten('inputfile.jl', 'ouput_dir', fields='fields_csv.csv', only_fields=True)
 ```
 
 ## Tables File
@@ -611,7 +611,7 @@ flatterer INPUT_FILE OUTPUT_DIRECTORY --tables tables.csv
 ```python
 import flatterer
 
-flatterer.flatten('inputfile.jl', 'ouput_dir', tables='tables.csv')
+flatterer.flatten('inputfile.jl', 'ouput_dir', tables_csv='tables.csv')
 ```
 
 ## Only Tables
@@ -629,7 +629,7 @@ flatterer INPUT_FILE OUTPUT_DIRECTORY --tables tables.csv --only-tables
 ```python
 import flatterer
 
-flatterer.flatten('inputfile.jl', 'ouput_dir', tables='tables.csv', only_tables=True)
+flatterer.flatten('inputfile.jl', 'ouput_dir', tables='tables_csv.csv', only_tables=True)
 ```
 
 ## Inline One To One


### PR DESCRIPTION
The docs list the arguments on `flatterer.flatten` as `fields` and `tables` for "Python Usage." However, when used, they result in `TypeError: flatten() got an unexpected keyword argument 'fields'` and `TypeError: flatten() got an unexpected keyword argument 'tables'`. As can be seen at [flatterer/\_\_init\_\_.py#73](https://github.com/kindly/flatterer/blob/b6c47fb6882f574d2a664d94ca3128784cb454fe/flatterer/__init__.py#L73) and [flatterer/\_\_init\_\_.py#75](https://github.com/kindly/flatterer/blob/b6c47fb6882f574d2a664d94ca3128784cb454fe/flatterer/__init__.py#L75), the arguments are actually `fields_csv` and `tables_csv` respectively. This change updates the documentation to reflect the correct argument names.

Note that the arguments for `flatterer.cli` are `fields` and `tables`. But that function is not documented for Python usage.